### PR TITLE
Add Crypto-Native Partnership Verification Standards

### DIFF
--- a/UBYX-0001-Crypto-Native-Partnership-Verification.md
+++ b/UBYX-0001-Crypto-Native-Partnership-Verification.md
@@ -1,0 +1,35 @@
+**Rule ID:** UBYX-0001
+**Title:** Crypto-Native Partnership Verification
+**Category:** Partnership Standards
+**Status:** draft
+**Version:** 1.0
+**Created:** 2025-01-02
+**Last Modified:** 2025-01-02
+**Author:** jaca8602
+**Description:** Establishes verification standards for crypto-native entities
+
+**Rule Overview**
+Defines verification requirements for blockchain-native organizations joining Ubyx, addressing the unique due diligence challenges when traditional financial institutions evaluate crypto ecosystem participants.
+
+**Obligations**
+
+1. **Operational Maturity:**
+   * Maintain live production systems for minimum 18 months with documented uptime
+   * Demonstrate successful partnership integrations with established ecosystem players
+   * Provide transparent incident response history and remediation processes
+
+2. **Ecosystem Reputation:**
+   * Submit verifiable references from current business partners or major protocol contributors
+   * Maintain active participation in relevant developer communities or industry forums
+   * Disclose regulatory status and any enforcement actions across all operating jurisdictions
+
+3. **Business Sustainability:**
+   * Document revenue diversification beyond speculative trading or token appreciation
+   * Demonstrate operational reserves adequate for 6-month runway during market stress
+   * Maintain professional liability coverage commensurate with network participation role
+
+**Non-Compliance Penalties**
+Non-compliance with these obligations may result in:
+* Probationary network access with enhanced reporting requirements
+* Escalated review process for rule modifications or new integrations
+* Network exclusion for material misrepresentation of operational capacity


### PR DESCRIPTION
This rule establishes verification standards for blockchain-native organizations seeking to join the Ubyx network.

**Background:**
Traditional financial institutions face unique challenges when evaluating crypto ecosystem participants. Standard due diligence processes often don't account for the operational characteristics of blockchain-native organizations.

**What this addresses:**
- Verification requirements that recognize crypto ecosystem maturity indicators
- Standards for evaluating operational track records in decentralized environments  
- Risk assessment frameworks appropriate for blockchain-native business models

**Based on practical experience:**
These standards draw from real-world challenges encountered when building partnerships between crypto-native and traditional finance entities, ensuring network integrity while avoiding unnecessarily restrictive barriers.

This rule supports Ubyx's mission of bridging traditional finance and Web3 by providing clear, practical verification standards that both ecosystems can understand and implement.