### PR TITLE
Add real-world examples to Rulebook participant types

### DIFF
--- a/rules/definitions/rulebook.md
+++ b/rules/definitions/rulebook.md
@@ -1,6 +1,6 @@
 The Ubyx Rulebook is the comprehensive set of binding rules, standards, and obligations that govern participation in the Ubyx stablecoin clearing system. It constitutes a legally enforceable contract between Ubyx Inc. and each Participant and is a condition of access to and continued use of the Ubyx platform.
 
-The Rulebook defines the rights and responsibilities of all categories of Participants—including Issuers, Receiving Institutions, and Settlement Banks—and establishes the operational, technical, compliance, and settlement framework within which all Participants must operate.
+The Rulebook defines the rights and responsibilities of all categories of Participants—including Issuers:(e.g Circle (USDC), Paxos (USDP), Tether (USDT), Receiving Institutions: (e.g Chime, PayPal, Payoneer), and Settlement Banks—and establishes the operational, technical, compliance, and settlement framework within which all Participants must operate.
 
 By executing a Participation Agreement or equivalent onboarding documentation, each Participant agrees to be bound by the Ubyx Rulebook in its entirety, including any amendments or supplements issued in accordance with its change control procedures.
 


### PR DESCRIPTION
Improves clarity by providing real-world examples of issuers and  receiving institutions. It makes the Rulebook more beginner-friendly — especially for those coming from traditional finance or early Web3.