### PR TITLE
Clarify Ubyx Token utility with governance and maintenance examples

### DIFF
--- a/rules/definitions/Ubyx Token.md
+++ b/rules/definitions/Ubyx Token.md
@@ -2,7 +2,7 @@ The Ubyx Token is a planned digital asset intended to support the future evoluti
 
 The Ubyx Token is envisioned as a utility token that may be used, in a future phase of the platform’s development, to facilitate progressive decentralisation of the Ubyx network. Potential use cases include:
 
-Participation in the governance and maintenance of the Ubyx Rulebook;
+Participation in the governance — such as proposing changes to the Rulebook, voting on redemption policies, or contributing compliance improvements and maintenance of the Ubyx Rulebook — such as clarifying or rewriting existing rules for better understanding.
 
 Payment of transaction fees within the Ubyx clearing system; and
 

--- a/rules/definitions/rulebook.md
+++ b/rules/definitions/rulebook.md
@@ -1,6 +1,6 @@
 The Ubyx Rulebook is the comprehensive set of binding rules, standards, and obligations that govern participation in the Ubyx stablecoin clearing system. It constitutes a legally enforceable contract between Ubyx Inc. and each Participant and is a condition of access to and continued use of the Ubyx platform.
 
-The Rulebook defines the rights and responsibilities of all categories of Participants—including Issuers, Receiving Institutions, and Settlement Banks—and establishes the operational, technical, compliance, and settlement framework within which all Participants must operate.
+The Rulebook defines the rights and responsibilities of all categories of Participants—including Issuers:(e.g Circle (USDC), Paxos (USDP), Tether (USDT), Receiving Institutions: (e.g Chime, PayPal, Payoneer), and Settlement Banks—and establishes the operational, technical, compliance, and settlement framework within which all Participants must operate.
 
 By executing a Participation Agreement or equivalent onboarding documentation, each Participant agrees to be bound by the Ubyx Rulebook in its entirety, including any amendments or supplements issued in accordance with its change control procedures.
 


### PR DESCRIPTION
This pull request adds specific examples to the "governance and maintenance" section of `Ubyx Token.md`.

It aims to clarify how token holders can actively participate in protocol governance (e.g., proposing Rulebook changes, voting on policies) and contribute to maintaining the Rulebook (e.g., improving clarity, updating definitions, fixing inconsistencies).

This addition helps contributors and future token holders better understand their roles and the utility of the Ubyx Token.
